### PR TITLE
Update info.md - Fix ZAP 404

### DIFF
--- a/info.md
+++ b/info.md
@@ -24,7 +24,7 @@
 
 - [OWASP AMASS](https://owasp.org/www-project-amass/)
 - [OWASP JuiceShop Project](https://owasp.org/www-project-juice-shop/)
-- [OWASP ZAP Project](https://owasp.org/www-project-zap)
+- [ZAP Project](https://zaproxy.org/)
 - [OWASP DefectDojo Project](https://owasp.org/www-project-defectdojo)
 
 ### Related Projects


### PR DESCRIPTION
ZAP is no longer an OWASP project.
https://www.zaproxy.org/blog/2023-08-01-zap-is-joining-the-software-security-project/