### PR TITLE
Add Jannik And Sven As Project Leads

### DIFF
--- a/leaders.md
+++ b/leaders.md
@@ -1,12 +1,15 @@
 ### Leaders
 
 * [Robert Felber](robert.seedorff@owasp.org)
+* [Jannik Hollenbach](jannik.hollenbach@owasp.org)
+* [Sven Strittmatter](sven.strittmatter@owasp.org)
 
 ### Maintainers
 
 * [Jannik Hollenbach](https://github.com/J12934)
 * [Sven Strittmatter](https://github.com/Weltraumschaf)
 * [Yannik Fuhrmeister](https://github.com/fuhrmeistery)
+
 ### Contributers
 
 * [Timo Pagel](https://github.com/wurstbrot)


### PR DESCRIPTION
The best practices from OWASP suggest a number greater than 1 for project leads. Good idea for reduncnacy and project resillience.

Since Jannik and me are the core maintainers for the last view years, we will take on it.